### PR TITLE
Update upload page information for clarity and detail

### DIFF
--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -168,11 +168,11 @@
 	},
 	"uploadPage": {
 		"pageHeader": "Upload Data",
-		"info": "Here you can upload a file with exchange data. \n\nThe file must be in the correct format for the upload to succeed (PDF or PNG). \nPlease contact the administrator for more information.",
+		"info": "Here you can upload a file with exchange data, for example Learning Agreement. \nThe file must be in the correct format for the upload to succeed (PDF or PNG). \n\nPlease contact us for more information.",
 		"name": "Name",
 		"email": "Email",
 		"file": "File",
-		"comment": "Comment (please include study program and specialization if not stated in the file)",
+		"comment": "Comment (please include study program, specialization, destination country, university, and study year if not included in the file)",
 		"submit": "Upload",
 		"clear": "Reset"
 	},

--- a/src/languages/no.json
+++ b/src/languages/no.json
@@ -168,11 +168,11 @@
 	},
 	"uploadPage": {
 		"pageHeader": "Last opp data",
-		"info": "Her kan du laste opp en fil med utvekslingsdata. \n\nFilen må være i riktig format for at opplastingen skal lykkes (PDF eller PNG). \nVennligst kontakt administrator for mer informasjon.",
+		"info": "Her kan du laste opp en fil med utvekslingsdata, for eksempel Learning Agreement. \nFilen må være i riktig format for at opplastingen skal lykkes (PDF eller PNG). \n\nVennligst kontakt oss for mer informasjon.",
 		"name": "Navn",
 		"email": "E-post",
 		"file": "Fil",
-		"comment": "Kommentar (skriv inn studie og spesialisering hvis det ikke er oppgitt i filen)",
+		"comment": "Kommentar \n\n(skriv inn studieprogram, spesialisering, destinasjonsland, universitet og studieår hvis det ikke er oppgitt i filen)",
 		"submit": "Last opp",
 		"clear": "Nullstill"
 	},


### PR DESCRIPTION
This pull request updates the upload page instructions in both English and Norwegian language files to provide clearer guidance to users about the required information when uploading exchange data files. The changes make the instructions more specific and user-friendly.

Content improvements to upload instructions:

* Clarified the `info` field to mention "Learning Agreement" as an example and changed the contact from "administrator" to "us" in both `en.json` and `no.json`. [[1]](diffhunk://#diff-302d4af2805c8a2005fe96c77d7e847e3484dac2115d8f7cf3cea06aa48099d8L171-R175) [[2]](diffhunk://#diff-3eedaef7783803d863df196de2e05d52e961ea11f1ace401ecdfd21f74c7f872L171-R175)
* Expanded the `comment` field instructions to request additional details (study program, specialization, destination country, university, and study year) if not included in the uploaded file, in both languages. [[1]](diffhunk://#diff-302d4af2805c8a2005fe96c77d7e847e3484dac2115d8f7cf3cea06aa48099d8L171-R175) [[2]](diffhunk://#diff-3eedaef7783803d863df196de2e05d52e961ea11f1ace401ecdfd21f74c7f872L171-R175)