### PR TITLE
Enhance exchange form validation and handling: add year change handle…

### DIFF
--- a/src/components/exchanges/EditExchange.vue
+++ b/src/components/exchanges/EditExchange.vue
@@ -84,7 +84,7 @@
 								</v-col>
 								<v-col cols="12" md="6">
 									<v-text-field v-model="userExchange.year" :label="$t('database.year')" type="number" clearable
-										required :hint="$t('hints.year')" persistent-hint />
+										required :hint="$t('hints.year')" @update:model-value="handleYearChange" persistent-hint />
 								</v-col>
 							</v-row>
 
@@ -127,7 +127,7 @@
 							<v-row>
 								<!-- Save Button -->
 								<v-col xs="12" md="2">
-									<v-btn @click="updateExchange" class="btn-primary" :disabled="!unsavedChanges">{{
+									<v-btn @click="updateExchange" class="btn-primary" :disabled="!canSaveExchange || !unsavedChanges">{{
 										$t("operations.save")
 									}}</v-btn>
 								</v-col>
@@ -623,8 +623,16 @@ export default {
 			const hasUnsavedChanges =
 				JSON.stringify(this.remoteExchange) !==
 				JSON.stringify(this.userExchange);
+
 			return hasUnsavedChanges;
 		},
+		canSaveExchange() {
+			return (
+				!this.missingBasicDataBool &&
+				!this.missingFallCoursesDataTotalBool &&
+				!this.missingSpringCoursesDataTotalBool
+			);
+		}
 	},
 	methods: {
 		loadData() {
@@ -764,7 +772,7 @@ export default {
 		},
 		removeCourse(semesterName, courseIndex) {
 			// Close the delete dialog
-			this.deleteDialog = false;
+			this.deleteCourseDialog = false;
 
 			// Get the courses for the specified semester
 			const semesterKey = semesterName.includes("Høst") ? "Høst" : "Vår";
@@ -801,6 +809,12 @@ export default {
 		handleCourseUpdate(updatedCourse) {
 			const { semester, courseIndex, course } = updatedCourse;
 			this.userExchange.courses[semester][courseIndex] = course;
+		},
+		handleYearChange(newYear) {
+			if (newYear == "") {
+				newYear = null;
+			}
+			this.userExchange.year = newYear;
 		},
 		getCountryIndex(selectedCountry) {
 			const translatedCountries = this.countryNamesTranslated;


### PR DESCRIPTION
This pull request improves the `EditExchange.vue` component by enhancing form validation and fixing minor UI issues related to course deletion and year input handling. The main focus is to ensure that the "Save" button is only enabled when all required data is present and to handle empty year inputs more gracefully.

**Form validation and user experience improvements:**

* Added a new computed property `canSaveExchange` to ensure the "Save" button is only enabled when all required data fields are filled in. The button is now disabled if any basic or course data is missing (`missingBasicDataBool`, `missingFallCoursesDataTotalBool`, or `missingSpringCoursesDataTotalBool`) [[1]](diffhunk://#diff-26f9339afd34f91f77145258b2d91421b6eef2675809a05a50c7f50ba5f6e314R626-R635) [[2]](diffhunk://#diff-26f9339afd34f91f77145258b2d91421b6eef2675809a05a50c7f50ba5f6e314L130-R130).
* Improved the year input field by adding an `@update:model-value` event handler (`handleYearChange`) to set the year to `null` if the input is cleared, preventing invalid empty string values [[1]](diffhunk://#diff-26f9339afd34f91f77145258b2d91421b6eef2675809a05a50c7f50ba5f6e314L87-R87) [[2]](diffhunk://#diff-26f9339afd34f91f77145258b2d91421b6eef2675809a05a50c7f50ba5f6e314R813-R818).

**Bug fixes:**

* Fixed a typo in the course deletion dialog variable, changing `this.deleteDialog` to `this.deleteCourseDialog` for consistency and to avoid potential bugs.