### PR TITLE
Prevent duplicate course additions in exchange grouping logic

### DIFF
--- a/src/components/courses/Courses.vue
+++ b/src/components/courses/Courses.vue
@@ -450,6 +450,21 @@ export default {
               university: exchange.university,
             };
 
+            let skip_addition = false;
+            for (const courseKey in grouped[code].courses) {
+              const oldCourse = grouped[code].courses[courseKey];
+              if (oldCourse.courseCode === courseWithMeta.courseCode &&
+                oldCourse.university === courseWithMeta.university &&
+                oldCourse.country === courseWithMeta.country) {
+                skip_addition = true;
+              }
+            }
+
+            if (skip_addition) {
+              skip_addition = false;
+              continue;
+            }
+
             grouped[code].courses.push(courseWithMeta);
 
             grouped[code].count = grouped[code].courses.length;


### PR DESCRIPTION
This pull request adds a safeguard to prevent duplicate courses from being added to the grouped courses list in the `Courses.vue` component. The change checks for existing courses with the same code, university, and country before adding a new one.

Duplicate prevention logic:

* Added a check to skip adding a course if a course with the same `courseCode`, `university`, and `country` already exists in the grouped list, preventing duplicate entries in `grouped[code].courses`.