### PR TITLE
Fix barchart names

### DIFF
--- a/src/components/home/BarChart.vue
+++ b/src/components/home/BarChart.vue
@@ -91,6 +91,29 @@ export default {
         yAxis: {
           type: "category",
           data: labels,
+          axisLabel: {
+            fontSize: 12,
+            formatter: (value) => {
+              const maxCharsPerLine = 20;     // adjust as needed
+              const words = value.split(" ");
+              let lines = [""];
+              let currentLine = 0;
+              for (let word of words) {
+                if ((lines[currentLine] + " " + word).trim().length <= maxCharsPerLine) {
+                  lines[currentLine] += (lines[currentLine] ? " " : "") + word;
+                } else {
+                  currentLine++;
+                  if (currentLine > 1) break; // stop after 3 lines
+                  lines[currentLine] = word;
+                }
+              }
+              // If text was too long for 3 lines → add ellipsis to last line
+              if (currentLine > 1) {
+                lines[1] += " ...";
+              }
+              return lines.join("\n");
+            }
+          },
           inverse: true,
         },
         series: [


### PR DESCRIPTION
This pull request improves the readability of y-axis labels in the `BarChart.vue` component by adding custom formatting logic. The most important change is the introduction of a formatter function that wraps long labels across multiple lines and adds an ellipsis if the label is too long.

Chart label formatting improvements:

* Added an `axisLabel.formatter` function to the y-axis configuration in `BarChart.vue` to split long labels into up to two lines (with a maximum of 20 characters per line), and append an ellipsis if the label exceeds the allowed length. This enhances label readability and prevents overflow in the chart display.