### PR TITLE
feat: save locale in cookies and update i18n initialization

### DIFF
--- a/src/components/common/Header.vue
+++ b/src/components/common/Header.vue
@@ -144,7 +144,7 @@ export default {
 		},
 		changeLanguage(lang) {
 			this.$i18n.locale = lang;
-			localStorage.setItem("language", lang);
+			document.cookie = `locale=${encodeURIComponent(lang)}; Path=/; Max-Age=31536000; SameSite=Lax`;
 			this.showLanguageDropdown = false;
 		},
 		handleClickOutside(event) {

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -1,6 +1,21 @@
 // src/i18n.js
 import { createI18n } from 'vue-i18n';
 
+function getCookie(name) {
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) {
+    return decodeURIComponent(parts.pop().split(";").shift());
+  }
+  return null;
+}
+
+const savedLocale =
+  getCookie("locale") ||
+  localStorage.getItem("language") ||
+  "no";
+
+
 const modules = import.meta.glob("../languages/no/*.json", { eager: true });
 const modulesEn = import.meta.glob("../languages/en/*.json", { eager: true });
 
@@ -18,11 +33,16 @@ for (const path in modulesEn) {
 }
 
 const i18n = createI18n({
-  legacy: true,            // <-- REQUIRED for $t() in templates
-  globalInjection: true,   // <-- makes $t() + $i18n available everywhere
-  locale: 'no',
-  messages: { no: messagesNo, en: messagesEn }
+  legacy: true,           // REQUIRED for $t()
+  globalInjection: true,  // makes $t() + $i18n available everywhere
+  locale: savedLocale,
+  fallbackLocale: "no",
+  messages: {
+    no: messagesNo,
+    en: messagesEn
+  }
 });
+
 
 
 // Export the global i18n instance


### PR DESCRIPTION
This pull request updates how the application's language preference is stored and retrieved, switching from localStorage to cookies for better persistence and compatibility. It also improves the initialization of the locale in the i18n setup to prioritize the cookie value, with a fallback to localStorage and a default.

**Language preference storage and retrieval:**

* Changed language selection in `Header.vue` to store the selected locale in a cookie instead of localStorage, ensuring the preference persists across sessions and is accessible server-side if needed.
* Added a `getCookie` function in `i18n.js` to retrieve the locale from cookies, and updated the logic to initialize the app's locale from the cookie first, then localStorage, then default to "no".

**i18n configuration improvements:**

* Updated the i18n initialization to use the detected/saved locale and set a fallback locale, ensuring the app always has a valid language setting.