### PR TITLE
fix: adjust header positioning and z-index for improved layout

### DIFF
--- a/src/components/common/Header.vue
+++ b/src/components/common/Header.vue
@@ -229,11 +229,14 @@ export default {
 
 <style scoped>
 header {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	z-index: 2000;
+
 	background-color: var(--fourth-color) !important;
 	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1) !important;
-	width: 100% !important;
-	top: 0 !important;
-	left: 0;
 	border-radius: 0 0 10px 10px;
 }
 


### PR DESCRIPTION
This pull request makes a small but important change to the header styling, ensuring that the header remains fixed at the top of the page and appears above other content.

- UI/Styling improvements:
  * Updated the `header` style in `Header.vue` to use `position: fixed` and increased `z-index` so the header stays visible at the top of the screen and overlays other elements.