### PR TITLE
fix: update country routing to use localized names on map click

### DIFF
--- a/src/components/home/WorldMap.vue
+++ b/src/components/home/WorldMap.vue
@@ -153,7 +153,7 @@ export default {
 				.style("pointer-events", (d) => (adjustedSet.has(d.properties.name) ? "all" : "none"))
 				.on("click", (event, d) => {
 					const key = topoNameToKey.get(d.properties.name) || d.properties.name;
-					this.routeToCountry(key);
+					this.routeToCountry(this.$t(`countries.${key}`));
 				})
 				.on("mouseover", (event, d) => {
 					if (!adjustedSet.has(d.properties.name)) return;
@@ -199,9 +199,6 @@ export default {
 				});
 
 			svg.call(zoom);
-
-			// (Optional) disable double-click zoom if you don't want it:
-			// svg.on("dblclick.zoom", null);
 		},
 		ensureTooltip() {
 			const id = "worldmap-tooltip";


### PR DESCRIPTION
This pull request introduces a minor update to the `WorldMap.vue` component, focusing on how country routing is handled when a country is clicked. The change ensures that routing uses the translated country name rather than the raw key, improving localization support.

- Routing and Localization:
  * Updated the click event handler to use the translated country name from the `$t` translation function when routing to a country. This change ensures that navigation respects the current language setting.

- Code Cleanup:
  * Removed commented-out code related to disabling double-click zoom, resulting in a cleaner and more maintainable codebase.