### PR TITLE
fix: update English name for Universidade Nova de Lisboa

### DIFF
--- a/src/data/universities.json
+++ b/src/data/universities.json
@@ -3242,7 +3242,7 @@
       },
       "Universidade Nova de Lisboa": {
         "original_name": "Universidade Nova de Lisboa",
-        "english_name": "New University of Lisbon",
+        "english_name": "Nova University of Lisbon",
         "abbreviation": "UNL",
         "original_city": "Lisboa",
         "english_city": "Lisbon"


### PR DESCRIPTION
This pull request updates the English name for "Universidade Nova de Lisboa" in the `universities.json` data file to better reflect its official English designation.

Data accuracy improvement:

* Changed the `english_name` field for "Universidade Nova de Lisboa" from "New University of Lisbon" to "Nova University of Lisbon" in `src/data/universities.json`.