### PR TITLE
fix: replace hardcoded Firebase database URL with environment variable

### DIFF
--- a/src/js/firebaseConfig.js
+++ b/src/js/firebaseConfig.js
@@ -10,8 +10,7 @@ const firebaseConfig = {
   messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
   appId: import.meta.env.VITE_FIREBASE_APP_ID,
   measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
-  databaseURL: 'https://utveksling-database-default-rtdb.europe-west1.firebasedatabase.app',
-
+  databaseURL: import.meta.env.VITE_FIREBASE_DATABASE_URL,
 };
 
 const app = initializeApp(firebaseConfig);


### PR DESCRIPTION
This pull request updates how the Firebase Realtime Database URL is configured in the application. Instead of hardcoding the database URL, it now uses an environment variable, making the configuration more flexible and secure.

Configuration improvements:

* Changed the `databaseURL` in `firebaseConfig` within `src/js/firebaseConfig.js` to use the `VITE_FIREBASE_DATABASE_URL` environment variable instead of a hardcoded URL.