### PR TITLE
171 bug double save race condition in editexchangevue

### DIFF
--- a/src/components/exchanges/EditExchange.vue
+++ b/src/components/exchanges/EditExchange.vue
@@ -64,7 +64,7 @@
 
 					<v-stepper-window-item :value="3">
 						<ReviewStep :userExchange="userExchange" :semesters="semesters" :canSubmit="canSaveExchange"
-							@submit="updateExchange" />
+							@submit="updateExchange" :saving="saving" />
 					</v-stepper-window-item>
 				</v-stepper-window>
 			</v-stepper>
@@ -320,6 +320,7 @@ export default {
 			selectedFile: null,
 			comment: "",
 			isSubmitting: false,
+			saving: false
 		};
 	},
 	watch: {
@@ -893,6 +894,8 @@ export default {
 			return cleanObject(payload);
 		},
 		async updateExchange() {
+			this.saving = true;
+
 			this.ensureSemesterCourses(this.semesters);
 
 			if (this.adminMode) {
@@ -922,6 +925,7 @@ export default {
 					console.error("Error updating user exchange data: ", error);
 					toast.error(this.$t("notifications.exchangeUpdateFailure"));
 				} finally {
+					this.saving = false;
 					refreshExchangesData();
 				}
 			} else {

--- a/src/components/exchanges/ReviewStep.vue
+++ b/src/components/exchanges/ReviewStep.vue
@@ -45,7 +45,8 @@
     </v-card>
 
     <!-- Submit -->
-    <v-btn v-if="showSubmitButton" color="success" size="large" :disabled="!canSubmit" @click="$emit('submit')">
+    <v-btn v-if="showSubmitButton" color="success" size="large" :disabled="!canSubmit || saving"
+      :loading="saving" @click="$emit('submit')">
       {{ $t("wizard.review.submit") }}
     </v-btn>
   </div>
@@ -60,6 +61,10 @@ export default {
     showSubmitButton: {
       type: Boolean,
       default: true,
+    },
+    saving: {
+      type: Boolean,
+      default: false,
     },
   },
   emits: ["submit"],


### PR DESCRIPTION
This pull request improves the user experience when submitting an exchange by adding a loading state to the submit button in the review step. Now, when a user submits an exchange, the button shows a loading indicator and is disabled to prevent duplicate submissions until the process is complete.

**User experience improvements:**

* Added a `saving` state to `EditExchange.vue` to track when the exchange is being submitted and passed this prop to the `ReviewStep` component. (`src/components/exchanges/EditExchange.vue`) [[1]](diffhunk://#diff-26f9339afd34f91f77145258b2d91421b6eef2675809a05a50c7f50ba5f6e314R323) [[2]](diffhunk://#diff-26f9339afd34f91f77145258b2d91421b6eef2675809a05a50c7f50ba5f6e314L67-R67) [[3]](diffhunk://#diff-26f9339afd34f91f77145258b2d91421b6eef2675809a05a50c7f50ba5f6e314R897-R898) [[4]](diffhunk://#diff-26f9339afd34f91f77145258b2d91421b6eef2675809a05a50c7f50ba5f6e314R928)
* Updated the submit button in `ReviewStep.vue` to show a loading indicator and disable itself while saving, using the new `saving` prop. (`src/components/exchanges/ReviewStep.vue`) [[1]](diffhunk://#diff-9584b61793e87f6e4bbfa5f51fca3689624083e7af4386f893af0e22dda2911bL48-R49) [[2]](diffhunk://#diff-9584b61793e87f6e4bbfa5f51fca3689624083e7af4386f893af0e22dda2911bR65-R68)