### PR TITLE
Remove redundant CSS class for green color

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -66,8 +66,7 @@
 	--text-2xl: 36px;
 }
 
-a,
-.green {
+a {
 	text-decoration: none;
 	color: var(--second-color);
 	transition: 0.4s;


### PR DESCRIPTION
This pull request makes a minor CSS adjustment to the styling of links and elements with the `.green` class. The `.green` class is no longer grouped with the `a` selector, so only `a` elements will receive the specified styles going forward.

- CSS selector update:
  * In `src/assets/css/main.css`, removed the `.green` class from the selector group so that only `a` elements are styled with `text-decoration: none`, the `--second-color`, and a `0.4s` transition.