### PR TITLE
Add display font for headings and update header font styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
 	<head>
 		<meta charset="UTF-8" />
 		<link rel="icon" type="image/png" href="/favicon.png" />
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@600;700&display=swap" rel="stylesheet" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Utvekslingsportalen</title>
 

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -66,6 +66,29 @@
 	--text-2xl: 36px;
 }
 
+h1, h2, h3 {
+	font-family: 'Plus Jakarta Sans', sans-serif;
+	color: var(--first-color);
+}
+
+h1 {
+	font-size: var(--text-2xl);
+	font-weight: 700;
+	line-height: 1.2;
+}
+
+h2 {
+	font-size: var(--text-xl);
+	font-weight: 700;
+	line-height: 1.25;
+}
+
+h3 {
+	font-size: var(--text-lg);
+	font-weight: 600;
+	line-height: 1.3;
+}
+
 a {
 	text-decoration: none;
 	color: var(--second-color);

--- a/src/components/common/Header.vue
+++ b/src/components/common/Header.vue
@@ -181,7 +181,8 @@ header {
 .site-name {
 	margin-left: 0.5rem;
 	font-size: 1.5rem;
-	font-weight: bold;
+	font-weight: 700;
+	font-family: 'Plus Jakarta Sans', sans-serif;
 }
 
 .nav-and-language {


### PR DESCRIPTION
This pull request updates the site's typography to use the "Plus Jakarta Sans" font for headings, aiming for a more modern and consistent look across the application. The changes include importing the font, updating heading styles, and applying the font to the site name in the header.

**Typography and Font Updates:**

* Added `<link>` tags to `index.html` to import the "Plus Jakarta Sans" font from Google Fonts and optimize font loading.
* Updated `main.css` to apply "Plus Jakarta Sans" to all `h1`, `h2`, and `h3` elements, and standardized their font weights, sizes, and line heights for better visual hierarchy.
* Modified the `.site-name` class in `Header.vue` to use "Plus Jakarta Sans" and set the font weight to 700 for consistency with heading styles.