### PR TITLE
Add normalization methods for ECTS points and course codes

### DIFF
--- a/src/components/exchanges/CourseForm.vue
+++ b/src/components/exchanges/CourseForm.vue
@@ -76,7 +76,23 @@ export default {
 			immediate: true,
 		},
 	},
-	methods: {},
+	methods: {
+		normalizeEcts() {
+			if (this.localCourse.ECTSPoints) {
+				this.localCourse.ECTSPoints = String(parseFloat(this.localCourse.ECTSPoints) || "");
+			}
+		},
+		normalizeCourseCode() {
+			if (this.localCourse.courseCode) {
+				this.localCourse.courseCode = this.localCourse.courseCode.toUpperCase().trim();
+			}
+		},
+		normalizeReplacedCourseCode() {
+			if (this.localCourse.replacedCourseCode) {
+				this.localCourse.replacedCourseCode = this.localCourse.replacedCourseCode.toUpperCase().trim();
+			}
+		}
+	},
 };
 </script>
 


### PR DESCRIPTION
This pull request enhances the `CourseForm` component by adding input normalization methods to ensure that course-related fields are consistently formatted before processing or saving. These changes help prevent data inconsistencies and improve user experience.

Input normalization improvements:

* Added a `normalizeEcts` method to convert the `ECTSPoints` field to a float and then back to a string, ensuring it is stored in a consistent numeric format.
* Added a `normalizeCourseCode` method to automatically convert the `courseCode` field to uppercase and trim whitespace.
* Added a `normalizeReplacedCourseCode` method to automatically convert the `replacedCourseCode` field to uppercase and trim whitespace.