### PR TITLE
Add Firebase database rules for user access and reporting

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -1,0 +1,44 @@
+{
+  "rules": {
+    "users": {
+      ".read": "auth != null",
+      ".write": "auth != null"
+    },
+
+    "exchanges": {
+      ".read": "true",
+      "$uid": {
+        ".write": "auth != null && (auth.uid === $uid || auth.uid === 'TaJF8H08JmQJ77NR8hUooUqfe0I2')"
+      },
+      ".indexOn": ["country", "university", "study", "specialization", "numSemesters"]
+    },
+
+    "exchangesTest": {
+      ".read": "true",
+      "$uid": {
+        ".write": "auth != null && (auth.uid === $uid || auth.uid === 'TaJF8H08JmQJ77NR8hUooUqfe0I2')"
+      },
+      ".indexOn": ["country", "university", "study", "specialization", "numSemesters"]
+    },
+
+    "faq": {
+      ".read": "true",
+      ".write": "auth != null && auth.uid === 'TaJF8H08JmQJ77NR8hUooUqfe0I2'"
+    },
+
+    "uploads": {
+      "$uid": {
+        ".read": "$uid === auth.uid",
+        ".write": "$uid === auth.uid"
+      }
+    },
+
+    "reports": {
+      ".read": "true",
+      ".indexOn": ["authorId", "university", "country", "status"],
+      "$reportId": {
+        ".write": "auth != null && ((!data.exists() && newData.child('authorId').val() === auth.uid) || (data.exists() && data.child('authorId').val() === auth.uid) || auth.uid === 'TaJF8H08JmQJ77NR8hUooUqfe0I2')"
+      }
+    }
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,7 @@
 {
+  "database": {
+    "rules": "database.rules.json"
+  },
   "hosting": {
     "public": "dist",
     "ignore": [


### PR DESCRIPTION
This pull request introduces a new set of Firebase Realtime Database security rules and integrates them into the Firebase configuration. The main focus is on defining granular access controls for different database collections, ensuring appropriate read and write permissions, and optimizing for query performance with indexing.

**Database security and configuration:**

* Added a new `database.rules.json` file specifying security rules for collections such as `users`, `exchanges`, `exchangesTest`, `faq`, `uploads`, and `reports`, including detailed read/write permissions and index configurations.
* Updated `firebase.json` to reference the new `database.rules.json` file, ensuring these rules are applied to the Firebase project.