### PR TITLE
Add keydown event handler for admin session reset

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -24,22 +24,38 @@
 
 <script setup>
 import { ref, onMounted, onUnmounted } from "vue";
+import { useStore } from "vuex";
 import Header from "./components/common/Header.vue";
 import MobileFooter from "./components/common/mobileFooter.vue";
 import Footer from "./components/common/Footer.vue";
 
+const store = useStore();
 const isDesktop = ref(window.innerWidth >= 769);
 
 const handleResize = () => {
 	isDesktop.value = window.innerWidth >= 769;
 };
 
+const handleKeydown = (e) => {
+	if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.code === "KeyL") {
+		e.preventDefault();
+		const adminId = import.meta.env.VITE_ADMIN_USER_ID;
+		const uid = store.getters.user?.uid;
+		if (uid && uid === adminId) {
+			sessionStorage.clear();
+			window.location.reload();
+		}
+	}
+};
+
 onMounted(() => {
 	window.addEventListener("resize", handleResize);
+	window.addEventListener("keydown", handleKeydown);
 });
 
 onUnmounted(() => {
 	window.removeEventListener("resize", handleResize);
+	window.removeEventListener("keydown", handleKeydown);
 });
 </script>
 


### PR DESCRIPTION
This pull request introduces a new keyboard shortcut for admin users to quickly clear session storage and reload the page. The logic is implemented in the root `App.vue` component and is only accessible to users whose ID matches the configured admin user ID.

**Admin shortcut feature:**

* Added a global keyboard event listener that listens for Ctrl+Shift+L (or Cmd+Shift+L) and, if the current user is the admin (as defined by `VITE_ADMIN_USER_ID`), clears `sessionStorage` and reloads the page. (`src/App.vue`)

**Lifecycle management:**

* Ensured the keyboard event listener is properly registered on mount and removed on unmount to prevent memory leaks. (`src/App.vue`)