### PR TITLE
Integrate reports navigation for admin users and restrict access

### DIFF
--- a/src/components/common/Header.vue
+++ b/src/components/common/Header.vue
@@ -22,6 +22,12 @@
 							}}</router-link>
 						</li>
 
+						<li v-if="checkAdminUser()">
+							<router-link to="/rapporter">{{
+								$t("nav.reportsHeader")
+							}}</router-link>
+						</li>
+
 						<li>
 							<router-link to="/kurs">{{
 								$t("nav.coursesHeader")

--- a/src/components/common/mobileFooter.vue
+++ b/src/components/common/mobileFooter.vue
@@ -66,6 +66,10 @@
 		<div v-if="showMenuDropdown">
 			<div class="menu-dropdown">
 				<div class="profile-content">
+					<router-link v-if="isAdminUser" class="footer-icon" to="/rapporter" @click="showMenuDropdown = false">
+						<v-icon size="30px">mdi-file-document-outline</v-icon>
+						<span>{{ $t("nav.reportsHeader") }}</span>
+					</router-link>
 					<router-link class="footer-icon" to="/kurs" @click="showMenuDropdown = false">
 						<v-icon size="30px">mdi-book-education-outline</v-icon>
 						<span>{{ $t("nav.coursesHeader") }}</span>
@@ -103,6 +107,9 @@ export default {
 	},
 	computed: {
 		...mapGetters(["isAuthenticated", "user", "userData"]),
+		isAdminUser() {
+			return this.user && this.user.uid === import.meta.env.VITE_ADMIN_USER_ID;
+		},
 	},
 	methods: {
 		toggleProfileDropdown() {

--- a/src/js/router.js
+++ b/src/js/router.js
@@ -188,6 +188,11 @@ router.beforeEach(async (to, from, next) => {
     return next({ name: 'Home' });
   }
 
+  const isReportsRoute = to.matched.some(record => ['Reports', 'ReportDetail', 'CreateReport'].includes(record.name));
+  if (isReportsRoute && (!adminUserId || !isAuthenticated || String(currentUserId) !== String(adminUserId))) {
+    return next({ name: 'Home' });
+  }
+
   if (to.name === 'Login' && isAuthenticated) {
     return next({ name: 'Account' });
   }

--- a/src/languages/en/nav.json
+++ b/src/languages/en/nav.json
@@ -10,5 +10,6 @@
   "myexchangeHeader": "My Exchange",
   "profile": "My Profile",
   "profileHeader": "Profile",
-  "programHeader": "Exchanges"
+  "programHeader": "Exchanges",
+  "reportsHeader": "Reports"
 }

--- a/src/languages/no/nav.json
+++ b/src/languages/no/nav.json
@@ -10,5 +10,6 @@
   "myexchangeHeader": "Min utveksling",
   "profile": "Min Profil",
   "profileHeader": "Profil",
-  "programHeader": "Utvekslinger"
+  "programHeader": "Utvekslinger",
+  "reportsHeader": "Rapporter"
 }


### PR DESCRIPTION
This pull request introduces a new "Reports" navigation item, visible only to admin users, and restricts access to the reports-related routes to admins. The changes ensure that only the designated admin user can see and access the reports section, both in the main header and mobile footer, and that other users are redirected if they attempt to access these routes. Additionally, translation keys for the new navigation item are added.

**Navigation and Access Control Updates:**

* Added a "Reports" (`/rapporter`) navigation link to the main header, visible only to admin users via the `checkAdminUser()` method.
* Added a "Reports" link to the mobile footer menu, also visible only to admin users by using a new computed property `isAdminUser`. [[1]](diffhunk://#diff-0fb3ff9d38f5108e67b1756284034d5191bf842c10482b0a3a7765c28d80224bR69-R72) [[2]](diffhunk://#diff-0fb3ff9d38f5108e67b1756284034d5191bf842c10482b0a3a7765c28d80224bR110-R112)
* Updated the router to restrict access to all reports-related routes (`Reports`, `ReportDetail`, `CreateReport`) so that only the admin user can access them; others are redirected to the home page.

**Localization:**

* Added the `reportsHeader` translation key to both English and Norwegian navigation language files. [[1]](diffhunk://#diff-65c84ed2c8ffa0d010740c258b14ce420045b5dc728329f4c5955949a066d75dL13-R14) [[2]](diffhunk://#diff-9ee4919b34eec098141adc5e50d57c0607a893c57308ed581b654ea390b3f8f9L13-R14)