### PR TITLE
Implement edit and delete functionality for user reports

### DIFF
--- a/src/components/reports/CreateReport.vue
+++ b/src/components/reports/CreateReport.vue
@@ -1,6 +1,6 @@
 <template>
 	<div>
-		<h2>{{ $t("reports.writeReport") }}</h2>
+		<h2>{{ editMode ? $t("reports.editReport") : $t("reports.writeReport") }}</h2>
 		<p class="page-summary">{{ $t("reports.info") }}</p>
 		<br />
 
@@ -187,7 +187,7 @@
 				</v-btn>
 				<v-btn v-else class="btn btn-primary" :disabled="!canSubmit" :loading="saving"
 					@click="submitReport">
-					{{ $t("reports.submit") }}
+					{{ editMode ? $t("reports.save") : $t("reports.submit") }}
 				</v-btn>
 			</v-col>
 		</v-row>
@@ -198,9 +198,10 @@
 import { mapGetters } from "vuex";
 import { auth } from "../../js/firebaseConfig";
 import { getExchangesData } from "../../js/exchangesCache";
-import { createReport } from "../../js/reportsCache";
+import { createReport, updateReport, getReportById } from "../../js/reportsCache";
 import universitiesData from "../../data/universities.json";
 import { toast } from "vue3-toastify";
+import { decryptId, encryptId } from "../../js/urlCipher";
 
 export default {
 	data() {
@@ -208,6 +209,7 @@ export default {
 			step: 1,
 			submitted: false,
 			saving: false,
+			editReportId: null,
 			universities: {},
 			report: {
 				title: "",
@@ -235,6 +237,10 @@ export default {
 
 	computed: {
 		...mapGetters(["user", "userData"]),
+
+		editMode() {
+			return !!this.editReportId;
+		},
 
 		countryNamesTranslated() {
 			return Object.keys(this.universities || {}).map((country) => ({
@@ -297,7 +303,35 @@ export default {
 
 	async mounted() {
 		this.universities = universitiesData.universities || {};
-		await this.prefillFromExchange();
+
+		const token = this.$route.params.id;
+		if (token) {
+			try {
+				const reportId = await decryptId(token);
+				const existing = await getReportById(reportId);
+				if (!existing || existing.authorId !== auth.currentUser?.uid) {
+					this.$router.replace({ name: "Reports" });
+					return;
+				}
+				this.editReportId = reportId;
+				this.report.title = existing.title || "";
+				this.report.anonymous = existing.anonymous || false;
+				this.report.country = existing.country || null;
+				this.report.university = existing.university || null;
+				this.report.study = existing.study || null;
+				this.report.year = existing.year || null;
+				this.report.semester = existing.semester || null;
+				this.report.content = existing.content || "";
+				this.report.tips = existing.tips || "";
+				this.report.ratings = { ...{ overall: 0, academic: 0, social: 0, housing: 0, costOfLiving: 0 }, ...existing.ratings };
+				this.report.pros = existing.pros?.length ? [...existing.pros] : [""];
+				this.report.cons = existing.cons?.length ? [...existing.cons] : [""];
+			} catch {
+				this.$router.replace({ name: "Reports" });
+			}
+		} else {
+			await this.prefillFromExchange();
+		}
 	},
 
 	methods: {
@@ -343,11 +377,18 @@ export default {
 					tips: this.report.tips.trim() || null,
 				};
 
-				await createReport(reportData);
-				toast.success(this.$t("notifications.reportCreated"));
-				this.$router.push({ name: "EditExchange" });
+				if (this.editMode) {
+					await updateReport(this.editReportId, reportData);
+					toast.success(this.$t("notifications.reportUpdated"));
+					const token = await encryptId(this.editReportId, "report");
+					this.$router.push({ name: "ReportDetail", params: { id: token } });
+				} else {
+					await createReport(reportData);
+					toast.success(this.$t("notifications.reportCreated"));
+					this.$router.push({ name: "EditExchange" });
+				}
 			} catch (error) {
-				console.error("Error creating report:", error);
+				console.error("Error saving report:", error);
 				toast.error(this.$t("notifications.reportError"));
 			} finally {
 				this.saving = false;

--- a/src/components/reports/ReportDetail.vue
+++ b/src/components/reports/ReportDetail.vue
@@ -116,10 +116,37 @@
 					<v-icon start>mdi-swap-horizontal</v-icon>
 					{{ $t("reports.viewExchange") }}
 				</v-btn>
+				<template v-if="isAuthor">
+					<v-btn variant="tonal" color="secondary" :to="editLink">
+						<v-icon start>mdi-pencil-outline</v-icon>
+						{{ $t("reports.edit") }}
+					</v-btn>
+					<v-btn variant="tonal" color="error" @click="deleteDialog = true">
+						<v-icon start>mdi-trash-can-outline</v-icon>
+						{{ $t("reports.delete") }}
+					</v-btn>
+				</template>
 				<v-spacer />
 				<v-btn variant="text" @click="copyLink">
 					<v-icon start>mdi-share-variant</v-icon>
 					{{ copied ? $t("reports.linkCopied") : $t("reports.share") }}
+				</v-btn>
+			</v-card-actions>
+		</v-card>
+	</v-dialog>
+
+	<!-- Delete confirmation dialog -->
+	<v-dialog v-model="deleteDialog" max-width="420">
+		<v-card rounded="xl">
+			<v-card-title class="pa-5 pb-2">{{ $t("reports.confirmDelete") }}</v-card-title>
+			<v-card-text class="pa-5 pt-1 text-medium-emphasis">
+				{{ $t("reports.confirmDeleteBody") }}
+			</v-card-text>
+			<v-card-actions class="pa-4 pt-0 ga-2">
+				<v-spacer />
+				<v-btn variant="text" @click="deleteDialog = false">{{ $t("reports.cancel") }}</v-btn>
+				<v-btn color="error" variant="tonal" :loading="deleting" @click="confirmDelete">
+					{{ $t("reports.delete") }}
 				</v-btn>
 			</v-card-actions>
 		</v-card>
@@ -129,9 +156,12 @@
 <script>
 import MarkdownIt from "markdown-it";
 import DOMPurify from "dompurify";
+import { mapGetters } from "vuex";
 import countriesInformation from "../../data/countriesInformation.json";
 import placeholderFlag from "../../assets/images/placeholder_flag.png";
 import { encryptId } from "../../js/urlCipher";
+import { deleteReport } from "../../js/reportsCache";
+import { toast } from "vue3-toastify";
 
 const md = new MarkdownIt({
 	html: false,
@@ -152,15 +182,29 @@ export default {
 	data() {
 		return {
 			copied: false,
+			deleteDialog: false,
+			deleting: false,
 			countriesInfo: countriesInformation,
 			ratingKeys: ["overall", "academic", "social", "housing", "costOfLiving"],
 			exchangeToken: null,
+			editToken: null,
 		};
 	},
 
 	computed: {
+		...mapGetters(["user"]),
+
 		locale() {
 			return this.$i18n.locale;
+		},
+
+		isAuthor() {
+			return this.user && this.report.authorId && this.user.uid === this.report.authorId;
+		},
+
+		editLink() {
+			if (!this.editToken) return null;
+			return { name: "EditReport", params: { id: this.editToken } };
 		},
 
 		ratingKeysLeft() {
@@ -194,11 +238,37 @@ export default {
 				this.exchangeToken = await encryptId(exchangeId, "exchange");
 			},
 		},
+
+		"report.id": {
+			immediate: true,
+			async handler(reportId) {
+				if (!reportId) {
+					this.editToken = null;
+					return;
+				}
+				this.editToken = await encryptId(reportId, "report");
+			},
+		},
 	},
 
 	methods: {
 		close() {
 			this.$emit("close");
+		},
+
+		async confirmDelete() {
+			this.deleting = true;
+			try {
+				await deleteReport(this.report.id);
+				toast.success(this.$t("notifications.reportDeleted"));
+				this.deleteDialog = false;
+				this.$emit("close");
+			} catch (error) {
+				console.error("Error deleting report:", error);
+				toast.error(this.$t("notifications.reportError"));
+			} finally {
+				this.deleting = false;
+			}
 		},
 
 		formatDate(timestamp) {

--- a/src/js/reportsCache.js
+++ b/src/js/reportsCache.js
@@ -106,7 +106,7 @@ export async function createReport(reportData) {
 
 export async function updateReport(reportId, reportData) {
   const db = getDatabase();
-  await set(dbRef(db, `reports/${reportId}`), {
+  await set(dbRef(db, `test_reports/${reportId}`), {
     ...reportData,
     updatedAt: Date.now(),
   });
@@ -122,6 +122,6 @@ export async function getReportsByExchangeId(exchangeId) {
 
 export async function deleteReport(reportId) {
   const db = getDatabase();
-  await remove(dbRef(db, `reports/${reportId}`));
+  await remove(dbRef(db, `test_reports/${reportId}`));
   clearCachedReports();
 }

--- a/src/js/router.js
+++ b/src/js/router.js
@@ -14,6 +14,7 @@ const Courses = () => import('../components/courses/Courses.vue');
 const Legal = () => import('../components/docs/Legal.vue');
 const Reports = () => import('../components/reports/Reports.vue');
 const CreateReport = () => import('../components/reports/CreateReport.vue');
+const EditReport = () => import('../components/reports/CreateReport.vue');
 
 import store, { authReadyPromise } from './store.js';
 
@@ -132,6 +133,17 @@ const routes = [
   },
 
   {
+    path: '/rapporter/:id/rediger',
+    name: 'EditReport',
+    component: EditReport,
+    meta: {
+      requiresAuth: true,
+      title: "Rediger rapport",
+      description: "Rediger din utvekslingsrapport."
+    }
+  },
+
+  {
     path: '/kurs',
     name: 'Courses',
     component: Courses,
@@ -188,7 +200,7 @@ router.beforeEach(async (to, from, next) => {
     return next({ name: 'Home' });
   }
 
-  const isReportsRoute = to.matched.some(record => ['Reports', 'ReportDetail', 'CreateReport'].includes(record.name));
+  const isReportsRoute = to.matched.some(record => ['Reports', 'ReportDetail', 'CreateReport', 'EditReport'].includes(record.name));
   if (isReportsRoute && (!adminUserId || !isAuthenticated || String(currentUserId) !== String(adminUserId))) {
     return next({ name: 'Home' });
   }


### PR DESCRIPTION
This pull request introduces the ability for users to edit and delete their own reports, as well as UI improvements to support these features. The main changes include adding an edit mode to the report creation component, implementing edit and delete actions in the report detail view, updating the router to support editing reports, and ensuring database operations use the correct path.

**Report Editing Feature:**
- Added an edit mode to `CreateReport.vue` that allows users to edit existing reports. The component loads report data if an ID is present in the route, updates the form labels and button text accordingly, and calls the new `updateReport` method on submit. [[1]](diffhunk://#diff-2049a54561cc37e2d53d46ad08fc394426d984a2aeebf9b7bdbb6f9d62bb71ffL3-R3) [[2]](diffhunk://#diff-2049a54561cc37e2d53d46ad08fc394426d984a2aeebf9b7bdbb6f9d62bb71ffL190-R190) [[3]](diffhunk://#diff-2049a54561cc37e2d53d46ad08fc394426d984a2aeebf9b7bdbb6f9d62bb71ffL201-R212) [[4]](diffhunk://#diff-2049a54561cc37e2d53d46ad08fc394426d984a2aeebf9b7bdbb6f9d62bb71ffR241-R244) [[5]](diffhunk://#diff-2049a54561cc37e2d53d46ad08fc394426d984a2aeebf9b7bdbb6f9d62bb71ffR306-R334) [[6]](diffhunk://#diff-2049a54561cc37e2d53d46ad08fc394426d984a2aeebf9b7bdbb6f9d62bb71ffR380-R391)
- Updated the router to add a new `EditReport` route and ensure it is protected and recognized as a reports route. [[1]](diffhunk://#diff-1fa4e1bb772d3565d1a4910ee48b8072d10246cb284069f758565d58fd8ba59bR17) [[2]](diffhunk://#diff-1fa4e1bb772d3565d1a4910ee48b8072d10246cb284069f758565d58fd8ba59bR135-R145) [[3]](diffhunk://#diff-1fa4e1bb772d3565d1a4910ee48b8072d10246cb284069f758565d58fd8ba59bL191-R203)

**Report Deletion Feature:**
- Added delete functionality to `ReportDetail.vue`, including a confirmation dialog and button only visible to the report author. The delete action calls the new `deleteReport` method and emits a close event on success. [[1]](diffhunk://#diff-fc4c865150366a723bde9c77e82ad11af38b5b13fb882f11b156da0a43b6d208R119-R128) [[2]](diffhunk://#diff-fc4c865150366a723bde9c77e82ad11af38b5b13fb882f11b156da0a43b6d208R137-R164) [[3]](diffhunk://#diff-fc4c865150366a723bde9c77e82ad11af38b5b13fb882f11b156da0a43b6d208R185-R209) [[4]](diffhunk://#diff-fc4c865150366a723bde9c77e82ad11af38b5b13fb882f11b156da0a43b6d208R241-R273)

**Database Path Consistency:**
- Updated `updateReport` and `deleteReport` in `reportsCache.js` to use the `test_reports` path for consistency with other operations. [[1]](diffhunk://#diff-15a22871283f33b3beea832c502103f6e0257639d89b3c001c650df5de3b425fL109-R109) [[2]](diffhunk://#diff-15a22871283f33b3beea832c502103f6e0257639d89b3c001c650df5de3b425fL125-R125)

These changes enable users to manage their reports more flexibly and improve the overall user experience for report authors.