### PR TITLE
Add font-display swap for Material Design Icons

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1,8 +1,3 @@
-@font-face {
-	font-family: "Material Design Icons";
-	font-display: swap;
-}
-
 :root {
 	--first-color: #112d4e;
 	/* Dark Blue */

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,10 +3,25 @@ import vue from '@vitejs/plugin-vue';
 import vuetify from 'vite-plugin-vuetify';
 import { fileURLToPath, URL } from 'node:url';
 
+// @mdi/font ships its @font-face without font-display, which blocks text
+// rendering until the icon font loads. Inject font-display: swap so icon
+// glyphs don't hold up the page's first paint.
+function mdiFontDisplaySwap() {
+  return {
+    name: 'mdi-font-display-swap',
+    enforce: 'pre',
+    transform(code, id) {
+      if (!id.includes('@mdi/font') || !id.endsWith('.css')) return null;
+      return code.replace(/@font-face\s*{/, '@font-face {\n  font-display: swap;');
+    },
+  };
+}
+
 export default defineConfig({
   plugins: [
     vue(),
     vuetify({ autoImport: true }),
+    mdiFontDisplaySwap(),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
This pull request addresses how the Material Design Icons font is loaded to improve page load performance and user experience. The main change is to ensure that the icon font uses `font-display: swap`, preventing icons from blocking the first paint of the page.

Font loading improvements:

* Added a custom Vite plugin (`mdiFontDisplaySwap`) in `vite.config.js` that automatically injects `font-display: swap` into the `@font-face` rule of the `@mdi/font` package, ensuring icon glyphs don't delay rendering.
* Removed the manual `@font-face` declaration from `src/assets/css/main.css`, as font handling is now managed by the new plugin.