### PR TITLE
Add font-display swap for Material Design Icons

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1,8 +1,3 @@
-@font-face {
-	font-family: "Material Design Icons";
-	font-display: swap;
-}
-
 :root {
 	--first-color: #112d4e;
 	/* Dark Blue */

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,10 +3,25 @@ import vue from '@vitejs/plugin-vue';
 import vuetify from 'vite-plugin-vuetify';
 import { fileURLToPath, URL } from 'node:url';
 
+// @mdi/font ships its @font-face without font-display, which blocks text
+// rendering until the icon font loads. Inject font-display: swap so icon
+// glyphs don't hold up the page's first paint.
+function mdiFontDisplaySwap() {
+  return {
+    name: 'mdi-font-display-swap',
+    enforce: 'pre',
+    transform(code, id) {
+      if (!id.includes('@mdi/font') || !id.endsWith('.css')) return null;
+      return code.replace(/@font-face\s*{/, '@font-face {\n  font-display: swap;');
+    },
+  };
+}
+
 export default defineConfig({
   plugins: [
     vue(),
     vuetify({ autoImport: true }),
+    mdiFontDisplaySwap(),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
This pull request updates how the `font-display` property is set for Material Design Icons (MDI) fonts. Instead of manually specifying `font-display: swap` in the project's CSS, it introduces a Vite plugin that automatically injects this property into the MDI font CSS. This ensures that icon fonts do not block text rendering, improving the page's first paint performance.

Font loading optimization:

* Added a custom Vite plugin (`mdiFontDisplaySwap`) in `vite.config.js` to automatically inject `font-display: swap` into the CSS provided by `@mdi/font`, ensuring icons don't delay text rendering.
* Removed the manual `@font-face` declaration for "Material Design Icons" from `src/assets/css/main.css`, since the plugin now handles `font-display`.