### PR TITLE
Split Vuetify into separate chunk to reduce bundle size

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -34,6 +34,7 @@ export default defineConfig({
         manualChunks: {
           'firebase': ['firebase/app', 'firebase/auth', 'firebase/database', 'firebase/storage', 'firebase/functions'],
           'vendor': ['vue', 'vue-router', 'vuex', 'vue-i18n'],
+          'vuetify': ['vuetify'],
         },
       },
     },


### PR DESCRIPTION
This pull request makes a small update to the Vite configuration by adding a separate manual chunk for the `vuetify` library. This change will help optimize the build output by splitting `vuetify` into its own bundle, potentially improving load performance.