### PR TITLE
Implement lazy loading for EditExchange and CreateExperience components

### DIFF
--- a/src/components/admin/Admin.vue
+++ b/src/components/admin/Admin.vue
@@ -131,14 +131,16 @@
 </template>
 
 <script>
+import { defineAsyncComponent } from "vue";
 import { mapGetters } from "vuex";
 import { db } from "../../js/firebaseConfig";
 import { ref as dbRef, get, set, update } from "firebase/database";
 import { toast } from "vue3-toastify";
 import Confirmation from "../common/Confirmation.vue";
-import EditExchange from "../exchanges/EditExchange.vue";
 
 import { getExchangesData, refreshExchangesData } from "../../js/exchangesCache";
+
+const EditExchange = defineAsyncComponent(() => import("../exchanges/EditExchange.vue"));
 
 export default {
 	components: { Confirmation, EditExchange },

--- a/src/components/profile/Account.vue
+++ b/src/components/profile/Account.vue
@@ -472,17 +472,19 @@
 </template>
 
 <script>
+import { defineAsyncComponent } from "vue";
 import { mapGetters } from "vuex";
 import { auth, db } from "../../js/firebaseConfig";
 import { signOut, sendEmailVerification, sendPasswordResetEmail } from "firebase/auth";
 import { ref as dbRef, update, set } from "firebase/database";
 import studiesData from "../../data/studies.json";
 import FavoriteCourses from "./FavoriteCourses.vue";
-import EditExchange from "../exchanges/EditExchange.vue";
-import CreateExperience from "../experiences/CreateExperience.vue";
 import { toast } from "vue3-toastify";
 import { getUserExperiences, deleteExperience } from "../../js/experiencesCache";
 import { getExchangesData, clearCachedExchanges } from "../../js/exchangesCache";
+
+const EditExchange = defineAsyncComponent(() => import("../exchanges/EditExchange.vue"));
+const CreateExperience = defineAsyncComponent(() => import("../experiences/CreateExperience.vue"));
 
 export default {
 	components: { FavoriteCourses, EditExchange, CreateExperience },


### PR DESCRIPTION
This pull request optimizes the way some components are loaded in the application by switching from static imports to asynchronous (lazy) loading. This change helps improve the initial load time and performance by only loading components when they are actually needed.

Component loading optimization:

* Converted the static imports of `EditExchange` and `CreateExperience` components to use Vue's `defineAsyncComponent` for lazy loading in both `Admin.vue` and `Account.vue`. This reduces the initial bundle size and speeds up page loads. [[1]](diffhunk://#diff-dfde98ee9e203c68bd1767760297d77df3e4076fa45a82d0134b00b7c57e01f2R134-R144) [[2]](diffhunk://#diff-101dc4a2b9288ed7e24ff653edc3cdeb93051801f19b3406819afabab4827f2cR475-R488)