### PR TITLE
Add authentication check for protected routes in router

### DIFF
--- a/src/js/router.js
+++ b/src/js/router.js
@@ -178,6 +178,15 @@ const router = createRouter({
 });
 
 router.beforeEach(async (to, from, next) => {
+  const needsAuthState = to.name === 'Admin' || to.name === 'Login' || to.matched.some(record => record.meta.requiresAuth);
+
+  // Public routes (e.g. Home) don't need to wait on Firebase auth to resolve
+  // before rendering — only routes whose navigation outcome depends on auth
+  // state (protected routes, Admin, Login) do.
+  if (!needsAuthState) {
+    return next();
+  }
+
   await authReadyPromise;
 
   const isAuthenticated = store.getters.isAuthenticated;


### PR DESCRIPTION
This pull request updates the route navigation guard logic in `src/js/router.js` to improve how authentication state is handled during navigation. The main change ensures that only routes dependent on authentication state (protected routes, `Admin`, and `Login`) wait for Firebase authentication to resolve before rendering, while public routes can render immediately.

Routing/authentication logic improvements:

* Updated the `beforeEach` navigation guard to check if the target route requires authentication state (`requiresAuth`, `Admin`, or `Login`). If not, navigation proceeds immediately without waiting for Firebase auth resolution, improving performance for public routes.