### PR TITLE
Refactor legal page layout and improve header consistency

### DIFF
--- a/src/components/admin/Admin.vue
+++ b/src/components/admin/Admin.vue
@@ -1,6 +1,6 @@
 <template>
 	<div>
-		<h2>{{ $t("admin.pageHeader") }}:</h2>
+		<h2>{{ $t("admin.pageHeader") }}</h2>
 	</div>
 	<br />
 	<v-container>

--- a/src/components/docs/Legal.vue
+++ b/src/components/docs/Legal.vue
@@ -1,58 +1,65 @@
 <template>
-  <v-container class="py-10" max-width="1100">
-    <v-row justify="center">
-      <v-col cols="12">
-        <v-card elevation="6" rounded="xl" class="pa-4 pa-sm-6">
-          <!-- Header -->
-          <div class="d-flex align-center justify-space-between flex-wrap mb-4">
-            <div>
-              <div class="text-h4 font-weight-bold">{{ $t("legal.legalPageTitle") }}</div>
-              <div class="text-body-2 text-medium-emphasis">
-                {{ $t("legal.legalPageDescription") }}
-              </div>
-            </div>
+  <div>
+    <h2>{{ $t("legal.legalPageTitle") }}</h2>
+    <p class="page-summary mb-1">
+      {{ $t("legal.legalPageDescription") }}
+    </p>
+    <p class="text-caption text-medium-emphasis updated-caption">
+      <v-icon size="14" class="mr-1">mdi-clock-outline</v-icon>
+      {{ $t("legal.updatedDate") }} 19-01-2026
+    </p>
 
-            <v-chip size="small" variant="tonal" color="primary">
-              {{ $t("legal.updatedDate") }} 19-01-2026
-            </v-chip>
-          </div>
+    <br />
 
-          <!-- Tabs -->
-          <v-tabs v-model="tab" color="primary" grow>
-            <v-tab value="overview">{{ $t("legal.overviewTab") }}</v-tab>
-            <v-tab value="privacy">{{ $t("legal.privacyTab") }}</v-tab>
-            <v-tab value="terms">{{ $t("legal.termsTab") }}</v-tab>
-            <v-tab value="disclaimer">{{ $t("legal.disclaimerTab") }}</v-tab>
-          </v-tabs>
+    <v-card class="legal-card" rounded="lg">
+      <v-card-text class="pa-4 pa-sm-6">
+        <!-- Tabs -->
+        <v-tabs v-model="tab" color="primary" grow>
+          <v-tab value="overview">
+            <v-icon start size="18">mdi-file-document-outline</v-icon>
+            {{ $t("legal.overviewTab") }}
+          </v-tab>
+          <v-tab value="privacy">
+            <v-icon start size="18">mdi-shield-lock-outline</v-icon>
+            {{ $t("legal.privacyTab") }}
+          </v-tab>
+          <v-tab value="terms">
+            <v-icon start size="18">mdi-gavel</v-icon>
+            {{ $t("legal.termsTab") }}
+          </v-tab>
+          <v-tab value="disclaimer">
+            <v-icon start size="18">mdi-alert-circle-outline</v-icon>
+            {{ $t("legal.disclaimerTab") }}
+          </v-tab>
+        </v-tabs>
 
-          <v-divider class="my-4" />
+        <v-divider class="my-4" />
 
-          <!-- Tab content -->
-          <v-window v-model="tab">
-            <v-window-item value="overview">
-              <MarkdownPanel v-if="this.$i18n.locale === 'en'" :content="overviewMdEn" @navigate="onNavigate" />
-              <MarkdownPanel v-else :content="overviewMdNo" @navigate="onNavigate" />
-            </v-window-item>
+        <!-- Tab content -->
+        <v-window v-model="tab">
+          <v-window-item value="overview">
+            <MarkdownPanel v-if="this.$i18n.locale === 'en'" :content="overviewMdEn" @navigate="onNavigate" />
+            <MarkdownPanel v-else :content="overviewMdNo" @navigate="onNavigate" />
+          </v-window-item>
 
-            <v-window-item value="privacy">
-              <MarkdownPanel v-if="this.$i18n.locale === 'en'" :content="privacyMdEn" @navigate="onNavigate" />
-              <MarkdownPanel v-else :content="privacyMdNo" @navigate="onNavigate" />
-            </v-window-item>
+          <v-window-item value="privacy">
+            <MarkdownPanel v-if="this.$i18n.locale === 'en'" :content="privacyMdEn" @navigate="onNavigate" />
+            <MarkdownPanel v-else :content="privacyMdNo" @navigate="onNavigate" />
+          </v-window-item>
 
-            <v-window-item value="terms">
-              <MarkdownPanel v-if="this.$i18n.locale === 'en'" :content="termsMdEn" @navigate="onNavigate" />
-              <MarkdownPanel v-else :content="termsMdNo" @navigate="onNavigate" />
-            </v-window-item>
+          <v-window-item value="terms">
+            <MarkdownPanel v-if="this.$i18n.locale === 'en'" :content="termsMdEn" @navigate="onNavigate" />
+            <MarkdownPanel v-else :content="termsMdNo" @navigate="onNavigate" />
+          </v-window-item>
 
-            <v-window-item value="disclaimer">
-              <MarkdownPanel v-if="this.$i18n.locale === 'en'" :content="disclaimerMdEn" @navigate="onNavigate" />
-              <MarkdownPanel v-else :content="disclaimerMdNo" @navigate="onNavigate" />
-            </v-window-item>
-          </v-window>
-        </v-card>
-      </v-col>
-    </v-row>
-  </v-container>
+          <v-window-item value="disclaimer">
+            <MarkdownPanel v-if="this.$i18n.locale === 'en'" :content="disclaimerMdEn" @navigate="onNavigate" />
+            <MarkdownPanel v-else :content="disclaimerMdNo" @navigate="onNavigate" />
+          </v-window-item>
+        </v-window>
+      </v-card-text>
+    </v-card>
+  </div>
 </template>
 
 <script>
@@ -129,3 +136,17 @@ export default {
   },
 }
 </script>
+
+<style scoped>
+.legal-card {
+  background-color: var(--color-bg-card);
+  border: 1px solid var(--third-color);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+}
+
+.updated-caption {
+  display: flex;
+  align-items: center;
+  margin: 0;
+}
+</style>

--- a/src/components/docs/MarkdownPanel.vue
+++ b/src/components/docs/MarkdownPanel.vue
@@ -1,7 +1,5 @@
 <template>
-  <v-card variant="tonal" rounded="xl" class="pa-5 pa-sm-6 mt-4">
-    <article class="markdown-body" v-html="html" @click="onClick" />
-  </v-card>
+  <article class="markdown-body" v-html="html" @click="onClick" />
 </template>
 
 <script>
@@ -51,10 +49,8 @@ export default {
 </script>
 
 <style scoped>
-/* Readable line length + slightly softer text */
 .markdown-body {
-  max-width: 76ch;
-  margin: 0 auto;
+  margin: 20px 32px 0;
   color: rgba(0, 0, 0, 0.84);
 }
 

--- a/src/components/profile/Login.vue
+++ b/src/components/profile/Login.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
-		<h2 v-if="login" class="sr-only">{{ $t("auth.loginTitle") }}:</h2>
-		<h2 v-else class="sr-only">{{ $t("auth.registerTitle") }}:</h2>
+		<h2 v-if="login" class="sr-only">{{ $t("auth.loginTitle") }}</h2>
+		<h2 v-else class="sr-only">{{ $t("auth.registerTitle") }}</h2>
 		<br />
 		<div class="login-container">
 			<v-card class="auth-card" elevation="1">

--- a/src/languages/en/courses.json
+++ b/src/languages/en/courses.json
@@ -6,7 +6,7 @@
   "fall": "Fall",
   "info": "Here you can explore what the courses at the host universities replace the courses in Norway.",
   "information": "Equivalent courses at host universities:",
-  "pageHeader": "Course Overview:",
+  "pageHeader": "Course Overview",
   "pageText": "Courses per page",
   "search": "Search for course code or course name",
   "searchInfo": "Search among {groups} {groupWord} with {exchanges} {exchangeWord}",

--- a/src/languages/en/exchanges.json
+++ b/src/languages/en/exchanges.json
@@ -12,7 +12,7 @@
   "info": "Here you can explore the exchange courses taken by previous students. \n\nYou can see which universities they have attended, which countries they have visited, and which courses they have taken. \nCompare with others in your study and create your own plan.",
   "loginToFavorite": "You need to be logged in to add or edit favorites",
   "noComments": "The student has not added any comments for this course.",
-  "pageHeader": "Previous Exchanges:",
+  "pageHeader": "Previous Exchanges",
   "pageText": "Exchanges per page",
   "search": "Search for country, university or study program",
   "searchInfo": "Search among {groups} {groupWord} in {location} {locationWord}"

--- a/src/languages/en/myExchange.json
+++ b/src/languages/en/myExchange.json
@@ -1,5 +1,5 @@
 {
-  "pageHeader": "Your Exchange:",
+  "pageHeader": "Your Exchange",
   "missingExchangePrompt": "You haven't added your exchange yet.",
   "clickToAdd": "Click to add information about your exchange.",
   "info": "Create or edit your overview of the courses you have taken during your exchange. \n\nCourse name and number of ECTS credits are required, where the ECTS credits should be converted from the university's local unit. \n\nIf your study program or specialization is not listed, please contact us.",

--- a/src/languages/no/courses.json
+++ b/src/languages/no/courses.json
@@ -6,7 +6,7 @@
   "fall": "Høst",
   "info": "Her kan du få en oversikt over hvilke fag hos de ulike utvekslingsuniversitetene som erstatter fagene i Norge.",
   "information": "Tilsvarende fag ved utvekslingsuniversiteter:",
-  "pageHeader": "Fagoversikt:",
+  "pageHeader": "Fagoversikt",
   "pageText": "Fag per side",
   "search": "Søk etter fag",
   "searchInfo": "Søk blant {groups} {groupWord} med {exchanges} {exchangeWord}",

--- a/src/languages/no/exchanges.json
+++ b/src/languages/no/exchanges.json
@@ -12,7 +12,7 @@
   "info": "Her kan du utforske utvekslingsfagene til tidligere studenter. \n\nDu kan se hvilke universiteter de har vært på, hvilke land de har besøkt, og hvilke fag de har tatt. \nSammenlign med andre på ditt studie og sett sammen din egen plan.",
   "loginToFavorite": "Du må være logget inn for å legge til eller endre favoritter",
   "noComments": "Studenten har ikke lagt inn noen kommentarer til dette faget.",
-  "pageHeader": "Tidligere utvekslinger:",
+  "pageHeader": "Tidligere utvekslinger",
   "pageText": "Utvekslinger per side",
   "search": "Søk etter land, universitet eller studieprogram",
   "searchInfo": "Søk blant {groups} {groupWord} i {location} {locationWord}"

--- a/src/languages/no/myExchange.json
+++ b/src/languages/no/myExchange.json
@@ -1,5 +1,5 @@
 {
-  "pageHeader": "Din utveksling:",
+  "pageHeader": "Din utveksling",
   "missingExchangePrompt": "Du har ikke lagt inn din utveksling ennå.",
   "clickToAdd": "Klikk for å legge til informasjon om din utveksling.",
   "info": "Opprett eller endre din oversikt over fagene du har tatt på utveksling. \n\nFagnavn og antall ECTS poeng er påkrevd, hvor ECTS poengene skal være konvertert fra universitetes lokale enhet. \n\nHvis ditt studieprogram eller spesialisering ikke finnes i listen, vennligst kontakt oss.",


### PR DESCRIPTION
This pull request updates several UI components and language files to improve consistency, visual clarity, and user experience, especially on the legal and authentication pages. The main changes include UI refinements for the legal documentation section, removal of unnecessary colons from page headers, and style adjustments for markdown content.

**UI and Visual Improvements:**

* Refactored the `Legal.vue` component to enhance readability and structure: replaced card-based headers with semantic HTML, added summary and updated date sections, integrated icons into tabs, and introduced a custom styled card for legal content. [[1]](diffhunk://#diff-e0b3e4b80afa181bbe9dca3bdf0cb58cd453749d7893bc3166589853826ba0deL2-R33) [[2]](diffhunk://#diff-e0b3e4b80afa181bbe9dca3bdf0cb58cd453749d7893bc3166589853826ba0deR60-R62) [[3]](diffhunk://#diff-e0b3e4b80afa181bbe9dca3bdf0cb58cd453749d7893bc3166589853826ba0deR139-R152)
* Updated `MarkdownPanel.vue` to remove the outer card wrapper, adjust margins for better readability, and simplify the style for markdown content. [[1]](diffhunk://#diff-0aa35ec0b5fed247c1294a1d45d69c17a6bb6c32b0b51646985c0c564b782950L2-L4) [[2]](diffhunk://#diff-0aa35ec0b5fed247c1294a1d45d69c17a6bb6c32b0b51646985c0c564b782950L54-R53)

**Text and Localization Consistency:**

* Removed unnecessary colons from page headers across English and Norwegian language files for courses, exchanges, and user exchange sections, as well as from related UI components like `Admin.vue` and `Login.vue`. [[1]](diffhunk://#diff-18aa54d6e0b0c2ddcdae8866f9491cf09bec13fc694676b703c03354f4bb1ddbL9-R9) [[2]](diffhunk://#diff-55d25c664fb3ce51dbf6757ff36229b495d4958d8d4b2c46fcd0084b51f23c46L15-R15) [[3]](diffhunk://#diff-003e331a8c2f0bfce3b49f43583a4ba8fb13a173721f4fe0896e21ece93cb271L2-R2) [[4]](diffhunk://#diff-e81d47a26200a648ca8952404216607116d291e491f769b456f1a3e0abaf24baL9-R9) [[5]](diffhunk://#diff-03fa838e4ae31331ff72e51e75c77f2b31d1a24fb750e75e849412458ee993cbL15-R15) [[6]](diffhunk://#diff-ac521c574fd55e16dc92a23c6634c902b3485c311931cf1ffc71aa6769d272dbL2-R2) [[7]](diffhunk://#diff-dfde98ee9e203c68bd1767760297d77df3e4076fa45a82d0134b00b7c57e01f2L3-R3) [[8]](diffhunk://#diff-d3530cd40b07fb8054e0079569e01d7b2b49071c0b7c9d2e9986746917b4b65dL3-R4)