### PR TITLE
Format experience dates by locale and enhance card layout

### DIFF
--- a/src/components/experiences/ExperienceDetail.vue
+++ b/src/components/experiences/ExperienceDetail.vue
@@ -289,7 +289,12 @@ export default {
 
 		formatDate(timestamp) {
 			if (!timestamp) return "";
-			return new Date(timestamp).toLocaleDateString();
+			const localeCode = this.locale === "no" ? "nb-NO" : "en-GB";
+			return new Date(timestamp).toLocaleDateString(localeCode, {
+				day: "2-digit",
+				month: "2-digit",
+				year: "numeric",
+			});
 		},
 
 		getFlagUrl(country) {

--- a/src/components/experiences/Experiences.vue
+++ b/src/components/experiences/Experiences.vue
@@ -67,12 +67,17 @@
 			<v-card v-for="experience in paginatedExperiences" :key="experience.id" class="experience-card"
 				variant="outlined" rounded="lg" @click="goToExperience(experience.id)">
 				<v-card-text>
-					<div class="d-flex align-center ga-2 mb-2">
-						<img v-if="experience.country" :src="getFlagUrl(experience.country)" alt="" width="24" height="18"
-							class="flag-img" />
-						<span class="text-caption text-medium-emphasis">
-							{{ experience.university || '—' }}
-						</span>
+					<div class="d-flex align-center justify-space-between ga-2 mb-2">
+						<div class="d-flex align-center ga-2">
+							<img v-if="experience.country" :src="getFlagUrl(experience.country)" alt="" width="24" height="18"
+								class="flag-img" />
+							<span class="text-caption text-medium-emphasis">
+								{{ experience.university || '—' }}
+							</span>
+						</div>
+						<v-chip v-if="experience.studyYear" size="x-small" variant="tonal" color="primary">
+							{{ experience.studyYear }} {{ $t('database.studyYear') }}
+						</v-chip>
 					</div>
 
 					<h3 class="experience-title">{{ experience.title }}</h3>
@@ -320,7 +325,12 @@ export default {
 
 		formatDate(timestamp) {
 			if (!timestamp) return "";
-			return new Date(timestamp).toLocaleDateString();
+			const localeCode = this.locale === "no" ? "nb-NO" : "en-GB";
+			return new Date(timestamp).toLocaleDateString(localeCode, {
+				day: "2-digit",
+				month: "2-digit",
+				year: "numeric",
+			});
 		},
 
 		getFlagUrl(country) {


### PR DESCRIPTION
This pull request improves the display of experience cards and standardizes date formatting in the experiences components. The most significant changes are the addition of a study year chip to each experience card and the use of locale-aware, consistent date formatting based on the user's selected language.

**UI Enhancements:**

* Added a `v-chip` to each experience card in `Experiences.vue` to display the `studyYear` when available, making it more visible and accessible to users.

**Date Formatting Improvements:**

* Updated the `formatDate` method in both `Experiences.vue` and `ExperienceDetail.vue` to use locale-specific formatting (`nb-NO` for Norwegian, `en-GB` for English), ensuring dates are consistently displayed in the correct format for the user's language. [[1]](diffhunk://#diff-5d166db990dc73e7a4e83568bd6b415d2768f6ee1e2fe3c55d5286ec8d05bf86L323-R333) [[2]](diffhunk://#diff-263403f007f6999cf749192af4192d0d4ef77cd676365077c14266ba88648a08L292-R297)