### PR TITLE
Enhance university chip layout and add items per page options

### DIFF
--- a/src/components/courses/Courses.vue
+++ b/src/components/courses/Courses.vue
@@ -25,7 +25,7 @@
   </div>
 
   <!-- University Chips -->
-  <div>
+  <div class="mt-4">
     <v-chip v-for="university in this.homeUniversities" size="large" class="mr-2" @click="toggleChip(university)"
       :class="selectedUniversity === university ? 'selected' : ''">
       {{ university.split('(')[1].split(')')[0] }}
@@ -36,7 +36,8 @@
   <div v-if="!isMobile">
     <v-data-table v-model:expanded="expanded" :headers="translatedHeaders" :items="filteredCourseList" item-value="id"
       show-expand class="main-table dense-table" id="main-table-width" :search="courseSearch"
-      :custom-filter="rowSearchFilter" :items-per-page-text="this.$t('courses.pageText')" :loading="coursetableLoading">
+      :custom-filter="rowSearchFilter" :items-per-page-text="this.$t('courses.pageText')"
+      :items-per-page-options="[10, 25, 50, 100]" :loading="coursetableLoading">
 
       <template v-slot:loading>
         <v-skeleton-loader type="table-row@10"></v-skeleton-loader>
@@ -93,7 +94,8 @@
     <v-data-table :headers="translatedMobileHeaders" v-model:expanded="expanded" :items="filteredCourseList"
       item-value="id" show-expand class="main-table fixed-table" id="main-table-width" :fixed-header="false"
       :style="{ width: '100%' }" item-class="custom-item-class" header-class="custom-header-class"
-      :search="courseSearch" :items-per-page-text="this.$t('courses.pageText')" :loading="coursetableLoading"
+      :search="courseSearch" :items-per-page-text="this.$t('courses.pageText')"
+      :items-per-page-options="[10, 25, 50, 100]" :loading="coursetableLoading"
       :custom-filter="rowSearchFilter">
 
       <template v-slot:loading>


### PR DESCRIPTION
This pull request makes improvements to the `Courses.vue` component, mainly enhancing the user interface and user experience for the courses table. The most important changes are:

**UI/UX Enhancements:**

* Added a top margin (`mt-4`) to the university chips container for better visual spacing.

**Table Functionality Improvements:**

* Added `:items-per-page-options="[10, 25, 50, 100]"` to both the desktop and mobile versions of the course table, allowing users to select how many items to display per page. [[1]](diffhunk://#diff-4a06a442a6eda66d4a73ebd38047afc2c7499089484a4adbbe0414454683f91bL39-R40) [[2]](diffhunk://#diff-4a06a442a6eda66d4a73ebd38047afc2c7499089484a4adbbe0414454683f91bL96-R98)