### PR TITLE
Sort courses by popularity and update data table options

### DIFF
--- a/src/components/courses/Courses.vue
+++ b/src/components/courses/Courses.vue
@@ -36,6 +36,7 @@
   <div v-if="!isMobile">
     <v-data-table v-model:expanded="expanded" :headers="translatedHeaders" :items="filteredCourseList" item-value="id"
       show-expand class="main-table dense-table" id="main-table-width" :search="courseSearch"
+      :sort-by="[{ key: 'count', order: 'desc' }]"
       :custom-filter="rowSearchFilter" :items-per-page-text="this.$t('courses.pageText')"
       :items-per-page-options="[10, 25, 50, 100]" :loading="coursetableLoading">
 
@@ -96,7 +97,7 @@
       :style="{ width: '100%' }" item-class="custom-item-class" header-class="custom-header-class"
       :search="courseSearch" :items-per-page-text="this.$t('courses.pageText')"
       :items-per-page-options="[10, 25, 50, 100]" :loading="coursetableLoading"
-      :custom-filter="rowSearchFilter">
+      :sort-by="[{ key: 'count', order: 'desc' }]" :custom-filter="rowSearchFilter">
 
       <template v-slot:loading>
         <v-skeleton-loader type="table-row@10"></v-skeleton-loader>
@@ -602,8 +603,9 @@ export default {
         this.courseList = Object.values(grouped);
         this.filteredCourseList = this.courseList;
 
-        // Sort by course code
+        // Sort by most common course first (highest count), then alphabetically by course code
         this.filteredCourseList.sort((a, b) => {
+          if (b.count !== a.count) return b.count - a.count;
           if (a.courseCode < b.courseCode) return -1;
           if (a.courseCode > b.courseCode) return 1;
           return 0;


### PR DESCRIPTION
This pull request updates the `Courses.vue` component to improve how courses are sorted and displayed in the course tables. The main focus is to ensure that courses with the highest count are shown first, both in the desktop and mobile table views, and to apply a secondary alphabetical sort by course code.

Sorting improvements:

* Added a default sort to both the desktop and mobile `v-data-table` components so that courses are sorted by `count` in descending order, ensuring the most common courses appear first. [[1]](diffhunk://#diff-4a06a442a6eda66d4a73ebd38047afc2c7499089484a4adbbe0414454683f91bR39) [[2]](diffhunk://#diff-4a06a442a6eda66d4a73ebd38047afc2c7499089484a4adbbe0414454683f91bL99-R100)
* Updated the sorting logic in the `filteredCourseList` array to sort first by descending `count` and then alphabetically by `courseCode` when counts are equal.